### PR TITLE
Add dummy header file to AVR_keywords

### DIFF
--- a/avr/libraries/AVR_keywords/AVR_keywords.h
+++ b/avr/libraries/AVR_keywords/AVR_keywords.h
@@ -1,0 +1,1 @@
+// This file causes the Arduino IDE to see AVR_keywords as a valid library


### PR DESCRIPTION
This causes Arduino IDE 1.6.6+ to see AVR_keywords as a valid library which allows the keywords to work correctly and fixes the Invalid library warning.