### PR TITLE
Unique library.properties names

### DIFF
--- a/avr/libraries/Ethernet/library.properties
+++ b/avr/libraries/Ethernet/library.properties
@@ -1,4 +1,4 @@
-name=Ethernet
+name=Ethernet(MightyCore)
 version=1.0.4
 author=Arduino
 maintainer=MCUdude

--- a/avr/libraries/SD/library.properties
+++ b/avr/libraries/SD/library.properties
@@ -1,4 +1,4 @@
-name=SD
+name=SD(MightyCore)
 version=1.0.5
 author=Arduino, SparkFun
 maintainer=MCUdude

--- a/avr/libraries/Servo/library.properties
+++ b/avr/libraries/Servo/library.properties
@@ -1,4 +1,4 @@
-name=Servo
+name=Servo(MightyCore)
 version=1.0.3
 author=Michael Margolis, Arduino
 maintainer=MCUdude


### PR DESCRIPTION
library.properties names that are unique from the Arduino IDE Built-in libraries names fixes the issue of libraries always showing as Type: Updatable in Library Manager when a MightyCore board is selected.