### PR TITLE
Add AVR_keywords library.properties

### DIFF
--- a/avr/libraries/AVR_keywords/library.properties
+++ b/avr/libraries/AVR_keywords/library.properties
@@ -1,0 +1,10 @@
+name=AVR keywords
+version=1.0
+author=MCUdude
+maintainer=MCUdude
+sentence=Highlights relevant AVR keywords in the Arduino IDE
+paragraph=
+category=Other
+url=https://github.com/MCUdude/MightyCore
+architectures=avr
+types=Arduino


### PR DESCRIPTION
Now that the folder structure of the AVR_keywords library is changed to 1.5 format(https://github.com/MCUdude/MightyCore/commit/bb7c0cffd68b49b4f072d4fe81761cad84501d13) Arduino IDE 1.6.6 and 1.6.7 gives an Invalid Library warning for the AVR_keywords library and the keyword highlighting doesn't work with those IDE versions. The library.properties file is the same as the one added in https://github.com/MCUdude/MightyCore/commit/bb7c0cffd68b49b4f072d4fe81761cad84501d13 except I have changed the category to a [valid value](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) to fix the warning and added the url field, without which the library is considered invalid(I believe this was the cause of the keywords no longer working as you stated in https://github.com/MCUdude/MightyCore/commit/7d476bbae185c04d25c47370967d6e07626cd268). I have tested this to work(keywords highlight and no warnings about the library) in Arduino IDE 1.6.4, 1.6.5-r5, 1.6.6, and 1.6.7.