### PR TITLE
Fix some compiler warnings

### DIFF
--- a/avr/cores/MightyCore_modified/wiring_analog.c
+++ b/avr/cores/MightyCore_modified/wiring_analog.c
@@ -51,7 +51,7 @@ int analogRead(uint8_t pin)
 #elif defined(__AVR_ATmega32U4__)
 	if (pin >= 18) pin -= 18; // allow for channel or pin numbers
 #elif defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644__) \
-|| defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__) \ 
+|| defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__) \
 || defined(__AVR_ATmega324__) || defined(__AVR_ATmega324P__) || defined(__AVR_ATmega324PA__) \
 || defined(__AVR_ATmega32__) || defined(__AVR_ATmega32A__) || defined(__AVR_ATmega164__) \
 || defined(__AVR_ATmega164P__) || defined(__AVR_ATmega164PA__) || defined(__AVR_ATmega16__) \

--- a/avr/cores/MightyCore_modified/wiring_private.h
+++ b/avr/cores/MightyCore_modified/wiring_private.h
@@ -58,7 +58,7 @@ uint32_t countPulseASM(volatile uint8_t *port, uint8_t bit, uint8_t stateMask, u
  || defined(__AVR_ATmega256RFR2__)
 #define EXTERNAL_NUM_INTERRUPTS 8
 #elif defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644__) \
-|| defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__) \ 
+|| defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__) \
 || defined(__AVR_ATmega324__) || defined(__AVR_ATmega324P__) || defined(__AVR_ATmega324PA__) \
 || defined(__AVR_ATmega32__) || defined(__AVR_ATmega32A__) || defined(__AVR_ATmega164__) \
 || defined(__AVR_ATmega164P__) || defined(__AVR_ATmega164PA__) || defined(__AVR_ATmega16__) \


### PR DESCRIPTION
Fixes `warning: backslash and newline separated by space` compiler warnings shown after compiler warnings are enabled(https://github.com/MCUdude/MightyCore/pull/11) when compiling for any MightyCore board with **File > Preferences > Compiler warnings: Default** or greater.