### PR TITLE
Add preprocessor recipes

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -80,6 +80,15 @@ recipe.size.regex=^(?:\.text|\.data|\.bootloader)\s+([0-9]+).*
 recipe.size.regex.data=^(?:\.data|\.bss|\.noinit)\s+([0-9]+).*
 recipe.size.regex.eeprom=^(?:\.eeprom)\s+([0-9]+).*
 
+## Preprocessor
+preproc.includes.flags=-w -x c++ -M -MG -MP
+recipe.preproc.includes="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.includes.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}"
+
+# The following line provides Arduino IDE 1.6.6 compatibility with the Arduino IDE 1.6.7 version of recipe.preproc.macros used here
+preprocessed_file_path=null
+preproc.macros.flags=-w -x c++ -E -CC
+recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{preprocessed_file_path}"
+
 
 # AVR Uploader/Programmers tools
 # ------------------------------


### PR DESCRIPTION
The default arduino [`recipe.preproc.includes`](https://github.com/arduino/arduino-builder/blob/master/src/arduino.cc/builder/hardware/platform.txt#L12) and [`recipe.preproc.macros`](https://github.com/arduino/arduino-builder/blob/master/src/arduino.cc/builder/hardware/platform.txt#L16) added in Arduino IDE 1.6.6 with arduino-builder don't have the `-mmcu={build.mcu}` option which causes the MCU specific macro to not be defined. For more information see https://github.com/arduino/arduino-builder/issues/106.

These are the [recipes](https://github.com/arduino/Arduino/blob/1.6.7/hardware/arduino/avr/platform.txt#L84-L89) from the Arduino AVR Boards 1.6.9 version included with Arduino IDE 1.6.7 with a default value of `null` set for [`preprocessed_file_path`](https://github.com/per1234/MightyCore/blob/preprocessor-recipes/avr/platform.txt#L87-L88) to allow for compatibility with Arduino IDE 1.6.6. Note that although the platform.txt included with Arduino IDE 1.6.6 and 1.6.7 both say they are version 1.6.9, the [`recipe.preproc.macros`](https://github.com/arduino/Arduino/blob/1.6.7/hardware/arduino/avr/platform.txt#L89) are [different](https://github.com/arduino/Arduino/blob/1.6.6/hardware/arduino/avr/platform.txt#L89).

I tested this for backwards compatibility back to Arduino IDE 1.6.2, the oldest version the previous platform.txt is compatible with.

**Demonstration of issue:**
- Tools > Board > ATmega1284
- Tools > Variant > ATmega1284P
- Compile using Arduino  IDE 1.6.6/1.6.7/hourly build:
```arduino
#ifndef __AVR_ATmega1284P__
#error __AVR_ATmega1284P__ not defined
#endif
void setup() {}
void loop() {}
```
Without this change the error will be incorrectly triggered.