### PR TITLE
Add copies of all Arduino AVR Boards programmers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ This core got two different pinout option. The default one is named "Standard", 
 </br> </br>
 <img src="http://i.imgur.com/PF1HWho.png" width="375"> <img src="http://i.imgur.com/fHC5LQK.png" width="430">
 
+##Programmers
+MightyCore adds its own copies of all the standard programmers to the "Programmer" menu. You must select the MightyCore copy of the programmer you are using for "Upload Using Programmer" to work with ATmega1284, ATmega324A, or ATmega164A.
+
 ##How to install
 #### Boards Manager Installation
 This installation method requires Arduino IDE version 1.6.4 or greater.

--- a/avr/avrdude.conf
+++ b/avr/avrdude.conf
@@ -1111,6 +1111,17 @@ programmer
   miso  = ~8;
 ;
 
+programmer
+  id = "dapa";
+  desc = "Direct AVR Parallel Access cable";
+  type = "par";
+  connection_type = parallel;
+  vcc   = 3;
+  reset = 16;
+  sck = 1;
+  mosi = 2;
+  miso = 11;
+;
 
 
 

--- a/avr/programmers.txt
+++ b/avr/programmers.txt
@@ -1,6 +1,6 @@
 
 
-stk500.name=STK500 as ISP
+stk500.name=STK500 as ISP (MightyCore)
 stk500.communication=serial
 stk500.protocol=stk500
 stk500.program.protocol=stk500
@@ -15,3 +15,65 @@ stk500.program.extra_params= -P {serial.port}
 #stk500hvpp.program.tool=avrdude
 #stk500hvpp.program.extra_params= -P {serial.port}
 
+# The following are the standard programmers from Arduino AVR Boards 1.6.9 with the name values modified to identify them as specific to MightyCore.
+# These are required for Upload Using Programmer to work with the MCUs added to the MightyCore avrdude.conf.
+
+avrisp.name=AVR ISP (MightyCore)
+avrisp.communication=serial
+avrisp.protocol=stk500v1
+avrisp.program.protocol=stk500v1
+avrisp.program.tool=avrdude
+avrisp.program.extra_params=-P{serial.port}
+
+avrispmkii.name=AVRISP mkII (MightyCore)
+avrispmkii.communication=usb
+avrispmkii.protocol=stk500v2
+avrispmkii.program.protocol=stk500v2
+avrispmkii.program.tool=avrdude
+avrispmkii.program.extra_params=-Pusb
+
+usbtinyisp.name=USBtinyISP (MightyCore)
+usbtinyisp.protocol=usbtiny
+usbtinyisp.program.tool=avrdude
+usbtinyisp.program.extra_params=
+
+arduinoisp.name=ArduinoISP (MightyCore)
+arduinoisp.protocol=arduinoisp
+arduinoisp.program.tool=avrdude
+arduinoisp.program.extra_params=
+
+usbasp.name=USBasp (MightyCore)
+usbasp.communication=usb
+usbasp.protocol=usbasp
+usbasp.program.protocol=usbasp
+usbasp.program.tool=avrdude
+usbasp.program.extra_params=-Pusb
+
+parallel.name=Parallel Programmer (MightyCore)
+parallel.protocol=dapa
+parallel.force=true
+# parallel.delay=200
+parallel.program.tool=avrdude
+parallel.program.extra_params=-F
+
+arduinoasisp.name=Arduino as ISP (MightyCore)
+arduinoasisp.communication=serial
+arduinoasisp.protocol=stk500v1
+arduinoasisp.speed=19200
+arduinoasisp.program.protocol=stk500v1
+arduinoasisp.program.speed=19200
+arduinoasisp.program.tool=avrdude
+arduinoasisp.program.extra_params=-P{serial.port} -b{program.speed}
+
+## Notes about Dangerous Prototypes Bus Pirate as ISP
+## Bus Pirate V3 need Firmware v5.10 or later
+## Bus Pirate V4 need Firmware v6.3-r2151 or later
+## Could happen that BP does not have enough current to power an Arduino board
+## through the ICSP connector. In this case disconnect the +Vcc from ICSP connector
+## and power Arduino board in the normal way.
+buspirate.name=BusPirate as ISP (MightyCore)
+buspirate.communication=serial
+buspirate.protocol=buspirate
+buspirate.program.protocol=buspirate
+buspirate.program.tool=avrdude
+buspirate.program.extra_params=-P{serial.port}


### PR DESCRIPTION
The platform.txt of the selected programmer is used for **Sketch > Upload Using Programmer**. This means that the MightyCore avrdude.conf is not used for **Upload Using Programmer** when any programmer not in the MightyCore programmers.txt is selected which causes failure(eg., `avrdude: AVR Part "atmega324a" not found.`) for any of the boards that require the added part definitions(ATmega1284, ATmega324A, and ATmega164A). This issue is fixed by selecting the MightyCore copy added in this commit from **Tools > Programmer**. 

These programmers are copied from Arduino AVR Boards 1.6.9 with only the `name` values modified to identify them as the MightyCore copies. I left off the **Atmel STK500 development board** programmer because it is identical to the **STK500 as ISP** programmer already included with MightyCore.

I have updated the readme to explain the purpose of the added programmers.

This is not a very nice workaround to this issue because it clutters up the **Tools > Programmer** menu, especially when you have multiple boards packages installed that do this but SpenceKonde([ATTinyCore](https://github.com/SpenceKonde/ATTinyCore/blob/master/avr/programmers.txt), [arduino-tiny-841](https://github.com/SpenceKonde/arduino-tiny-841/blob/master/avr/programmers.txt)), thomasonw([ATmegaCAN](https://github.com/thomasonw/ATmegaCAN/blob/master/avr/programmers.txt)), and [I](https://github.com/per1234/Arduino-AVRISPmkII-fix) have spent quite a bit of time trying to find a better solution with no success. Adafruit also had this [problem](https://github.com/arduino/Arduino/issues/2886) with their ATtiny board but they were able to get Arduino to modify their avrdude.conf so that could be another option to submit your added parts as a pull request to the Arduino IDE repository and see if it will be merged. So I'm not sure if you will consider this change worth making or maybe you can think of a better way.

I'm happy to make any changes you request and squash to a single commit.

Demonstration of issue:
- Tools > Board > ATmega1284
- Tools > Variant > 1284
- Tools > Programmer > any programmer except for STK500 as ISP
- Sketch > Upload Using Programmer - fails with the error: `avrdude: AVR Part "atmega1284" not found.` If you look at the avrdude command you can see that the Arduino AVR Boards avrdude.conf was specified.