### PR TITLE
Update boards.txt core value

### DIFF
--- a/avr/boards.txt
+++ b/avr/boards.txt
@@ -14,7 +14,7 @@ menu.variant=Variant
 1284.bootloader.unlock_bits=0x3f
 1284.bootloader.lock_bits=0x0f
 
-1284.build.core=MightyCore_modified
+1284.build.core=MightyCore
 1284.build.board=AVR_ATmega1284
 
 1284.menu.pinout.standard=Standard
@@ -92,7 +92,7 @@ menu.variant=Variant
 644.bootloader.unlock_bits=0x3f
 644.bootloader.lock_bits=0x0f
 
-644.build.core=MightyCore_modified
+644.build.core=MightyCore
 644.build.board=AVR_ATmega644
 
 644.menu.pinout.standard=Standard
@@ -169,7 +169,7 @@ menu.variant=Variant
 324.bootloader.unlock_bits=0x3f
 324.bootloader.lock_bits=0x0f
 
-324.build.core=MightyCore_modified
+324.build.core=MightyCore
 324.build.board=AVR_ATmega324
 
 324.menu.pinout.standard=Standard
@@ -248,7 +248,7 @@ menu.variant=Variant
 164.bootloader.unlock_bits=0x3f
 164.bootloader.lock_bits=0x0f
 
-164.build.core=MightyCore_modified
+164.build.core=MightyCore
 164.build.board=AVR_ATmega164
 
 164.menu.pinout.standard=Standard
@@ -326,7 +326,7 @@ menu.variant=Variant
 32.bootloader.lock_bits=0x0f
 
 32.build.mcu=atmega32
-32.build.core=MightyCore_modified
+32.build.core=MightyCore
 32.build.board=AVR_ATmega32
 
 32.menu.pinout.standard=Standard
@@ -389,7 +389,7 @@ menu.variant=Variant
 16.bootloader.lock_bits=0x0f
 
 16.build.mcu=atmega16
-16.build.core=MightyCore_modified
+16.build.core=MightyCore
 16.build.board=AVR_ATmega16
 
 16.menu.pinout.standard=Standard
@@ -452,7 +452,7 @@ menu.variant=Variant
 8535.bootloader.lock_bits=0x0f
 
 8535.build.mcu=atmega8535
-8535.build.core=MightyCore_modified
+8535.build.core=MightyCore
 8535.build.board=AVR_ATmega8535
 
 8535.menu.pinout.standard=Standard


### PR DESCRIPTION
The core folder name was changed from MightyCore_modified to MightyCore in https://github.com/MCUdude/MightyCore/commit/10f0d0db5b49dd0efded067dd09ba0ec211c7c21 which caused
```
C:\Users\per\AppData\Local\Temp\build9224cc121f2e0c719046ad54c33ee91a.tmp\sketch\sketch_mar05a.ino.cpp:1:21: fatal error: Arduino.h: No such file or directory
 #include <Arduino.h>
```
error.