### PR TITLE
Update recipe.ar.pattern

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -60,7 +60,8 @@ recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -m
 recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives (We need to keep {build.path}/{archive_file} to keep backwards compability)
-recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{build.path}/{archive_file}" "{object_file}"
+archive_file_path={build.path}/{archive_file}
+recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}"
 
 
 ## Combine gc-sections, archives, and objects


### PR DESCRIPTION
Change recipe.ar.pattern to the new recipe added in Arduino AVR Boards 1.6.9. The previous recipe causes:
```
Warning: platform.txt from core 'MightyCore' contains deprecated recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{build.path}/{archive_file}" "{object_file}", automatically converted to recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}". Consider upgrading this core.
```
in Arduino IDE 1.6.6+.

I have added the line:
```
archive_file_path={build.path}/{archive_file}
```
to allow for backwards compatibility with Arduino IDE 1.6.5-r5 and previous(tested back to Arduino IDE 1.6.2, the oldest version that MightyCore was previously compatible with). Without this line the updated recipe causes:
```
avr-gcc: error:  C:\Users\per\AppData\Local\Temp\build2567746225989664165.tmp/core.a: No such file or directory
```
This change results in avr-ar commands identical to the previous recipe.