### PR TITLE
Improve recipe.preproc.macros IDE 1.6.6 compatibility

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -85,7 +85,7 @@ preproc.includes.flags=-w -x c++ -M -MG -MP
 recipe.preproc.includes="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.includes.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}"
 
 # The following line provides Arduino IDE 1.6.6 compatibility with the Arduino IDE 1.6.7 version of recipe.preproc.macros used here
-preprocessed_file_path=null
+preprocessed_file_path={build.path}/nul
 preproc.macros.flags=-w -x c++ -E -CC
 recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{preprocessed_file_path}"
 


### PR DESCRIPTION
With Arduino IDE 1.6.6(only) the previous default preprocessed_file_path value set in platform.txt was causing a file named null to be created in the root of the Arduino IDE installation folder which can be avoided on Windows by using the filename nul. A file named nul will still be created on other OSs but now will be placed in the temporary build folder which will avoid possible problems if the user doesn't have write permission to the IDE installation folder.

- **IDE 1.6.5-r5 and previous**: recipe.preproc.macros is not used at all.
- **IDE 1.6.6**: The default value of preprocessed_file_path set in platform.txt is used in the recipe.preproc.macros avr-g++ command.
  - Windows: The output is written to the null device so no file is created which is the same result as produced by the Arduino AVR Boards 1.6.9 version included with Arduino IDE 1.6.6.
  - Linux or Mac OS X(untested): The output is written to a file named nul in the temporary build folder.
- **IDE 1.6.7+**: The default value of preprocessed_file_path set in platform.txt is overridden by the value set by the IDE so the generated recipe.preproc.macros avr-g++ command is identical to the one if no default value was specified.