### PR TITLE
Remove toolsDependencies items

### DIFF
--- a/package_MCUdude_MightyCore_index.json
+++ b/package_MCUdude_MightyCore_index.json
@@ -30,18 +30,7 @@
             {"name": "ATmega16"},
             {"name": "ATmega8535"}
           ],
-          "toolsDependencies": [
-            {
-              "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
-            },
-            {
-              "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
-            }
-          ]
+          "toolsDependencies": []
         },
         {
           "name": "MightyCore",
@@ -64,18 +53,7 @@
             {"name": "ATmega16"},
             {"name": "ATmega8535"}
           ],
-          "toolsDependencies": [
-            {
-              "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
-            },
-            {
-              "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
-            }
-          ]
+          "toolsDependencies": []
         },
         {
           "name": "MightyCore",
@@ -98,18 +76,7 @@
             {"name": "ATmega16"},
             {"name": "ATmega8535"}
           ],
-          "toolsDependencies": [
-            {
-              "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
-            },
-            {
-              "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
-            }
-          ]
+          "toolsDependencies": []
         },
         {
           "name": "MightyCore",
@@ -132,18 +99,7 @@
             {"name": "ATmega16"},
             {"name": "ATmega8535"}
           ],
-          "toolsDependencies": [
-            {
-              "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
-            },
-            {
-              "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
-            }
-          ]
+          "toolsDependencies": []
         },
         {
           "name": "MightyCore",
@@ -166,18 +122,7 @@
             {"name": "ATmega16"},
             {"name": "ATmega8535"}
           ],
-          "toolsDependencies": [
-            {
-              "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
-            },
-            {
-              "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
-            }
-          ]
+          "toolsDependencies": []
         },
         {
           "name": "MightyCore",
@@ -200,18 +145,7 @@
             {"name": "ATmega16"},
             {"name": "ATmega8535"}
           ],
-          "toolsDependencies": [
-            {
-              "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
-            },
-            {
-              "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
-            }
-          ]
+          "toolsDependencies": []
         },
         {
           "name": "MightyCore",
@@ -234,18 +168,7 @@
             {"name": "ATmega16"},
             {"name": "ATmega8535"}
           ],
-          "toolsDependencies": [
-            {
-              "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
-            },
-            {
-              "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
-            }
-          ]
+          "toolsDependencies": []
         }
       ],
       "tools": []


### PR DESCRIPTION
Previously, installing MightyCore in Arduino IDE 1.6.10 caused the
installation of avr-gcc 4.8.1-arduino5. This forced Arduino AVR Boards
1.6.12 to use that avr-gcc version, which it is incompatible with,
causing compiling any Arduino AVR Board to fail.

Now that no tools dependencies are listed, MightyCore will use whatever
version of these tools is currently installed in the Arduino IDE(avr-gcc
4.8.1-arduino5 in Arduino IDE 1.6.9 and previous, avr-gcc
4.9.2-atmel3.5.3-arduino2 in Arduino IDE 1.6.10).

Boards Manager URL for testing:
https://raw.githubusercontent.com/per1234/MightyCore/remove-tools-dependencies/package_MCUdude_MightyCore_index.json