### PR TITLE
Fix image embeds in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,10 +214,13 @@ The development board got some additional unique features:
 #### [The development board can be bought on my Tindie store.](https://www.tindie.com/products/MCUdude/dip-40-arduino-compatible-development-board/) This includes a pre programmed ATmega32. <br/>
 <br/>
 Click the images for full resolution <br/>
+
 ![Development board front](http://i.imgur.com/0ZqEKS8.jpg)
 <br/>
-![Development board back](http://i.imgur.com/O4kskqP.jpg[)
+
+![Development board back](http://i.imgur.com/O4kskqP.jpg)
 <br/>
+
 ![Pinouts](http://i.imgur.com/ex733X6.jpg)
 
 ## Minimal setup


### PR DESCRIPTION
This was probably broken by GitHub's recent Markdown interpreter change.

README.md as it appears prior to this change:
![clipboard01](https://cloud.githubusercontent.com/assets/8572152/25043787/6c0b9a8a-20d7-11e7-972c-c07f24be6920.png)
