### PR TITLE
Fix invalid preprocessor directive in Blink_using_Timer0 example

### DIFF
--- a/avr/libraries/AVR_examples/examples/Blink_using_Timer0/Blink_using_Timer0.ino
+++ b/avr/libraries/AVR_examples/examples/Blink_using_Timer0/Blink_using_Timer0.ino
@@ -30,7 +30,7 @@ int main (void)
     TCNT0 = 0; // Start to count from zero
     TIMSK = 0x01; // Enable overflow interrupt
 
-  #elseif defined(__AVR_ATmega164P__) || defined(__AVR_ATmega324P__) \
+  #elif defined(__AVR_ATmega164P__) || defined(__AVR_ATmega324P__) \
   || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega1284P__)
     TCCR0B = 0x05; // clock frequency / 1024 
     OCR0B = 0x00;  // Output compare


### PR DESCRIPTION
The use of the invalid preprocessor directive `#elseif` caused compilation of this sketch to fail for ATmega16/32/8535.