### PR TITLE
Fix math in Timer library example

### DIFF
--- a/avr/libraries/Timer/examples/Pin_high_10_minutes/Pin_high_10_minutes.ino
+++ b/avr/libraries/Timer/examples/Pin_high_10_minutes/Pin_high_10_minutes.ino
@@ -12,7 +12,7 @@
 
 int ledPin = 0;                   // LED is attached to digital pin 0
 int tenSeconds = 10 * 1000;       // 10000 ms
-long tenMinutes = 10 * 60 * 1000; // 600000 ms
+long tenMinutes = 10 * 60 * 1000L; // 600000 ms
 
 Timer t; // Object of the timer class
 


### PR DESCRIPTION
Previously, the math in would result in a pulse of 10176 ms rather than the promised 600000 ms due to integer overflow.