### PR TITLE
Fix unused parameter warning in Timer example

### DIFF
--- a/avr/libraries/Timer/examples/Multitasking/Multitasking.ino
+++ b/avr/libraries/Timer/examples/Multitasking/Multitasking.ino
@@ -46,5 +46,6 @@ void takeReading(void* context)
 }
 
 void toggle(void* context) {
+  (void)context;  // Cast unused parameter to void to avoid compiler warning
   digitalWrite(ledPin, !digitalRead(ledPin)); // Toggle the ledPin
 }


### PR DESCRIPTION
Cast to void unused parameter in the `toggle()` callback to fix the warning:
```
E:\electronics\arduino\hardware\MightyCore\avr\libraries\Timer\examples\Multitasking\Multitasking.ino:48:19: warning: unused parameter 'context' [-Wunused-parameter]

 void toggle(void* context) {

                   ^
```