### PR TITLE
Fix Servo library unused parameter warning

### DIFF
--- a/avr/libraries/Servo/src/Servo.cpp
+++ b/avr/libraries/Servo/src/Servo.cpp
@@ -203,7 +203,8 @@ static void finISR(timer16_Sequence_t timer)
     timerDetach(TIMER3OUTCOMPAREA_INT);
   }
 #else
-    //For arduino - in future: call here to a currently undefined function to reset the timer
+  //For arduino - in future: call here to a currently undefined function to reset the timer
+  (void) timer;  // squash "unused parameter 'timer' [-Wunused-parameter]" warning
 #endif
 }
 


### PR DESCRIPTION
Previously, compilation of any code using the Servo caused the warning:
```
E:\electronics\arduino\hardware\MightyCore\avr\libraries\Servo\src\Servo.cpp:185:39: warning: unused parameter 'timer' [-Wunused-parameter]

 static void finISR(timer16_Sequence_t timer)

                                       ^
```
Reference:
https://github.com/arduino-libraries/Servo/commit/2706a5c114cbd2b0cc31659d211fd918901b5e35