### PR TITLE
Remove jobs that now fail due to switch to PaulStoffregen/Ethernet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,13 +105,11 @@ env:
     # clock=8MHz_internal
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/Ethernet/examples/DhcpAddressPrinter/DhcpAddressPrinter.ino" BOARD_ID="MightyCore:avr:164:pinout=standard,variant=modelP,BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
 
-    # Ethernet/DhcpChatServer
-    # Compiling with LTO=Os errors with "Sketch too big"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/Ethernet/examples/DhcpChatServer/DhcpChatServer.ino" BOARD_ID="MightyCore:avr:164:pinout=standard,variant=modelP,BOD=2v7,LTO=Os_flto,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    # Ethernet/DhcpChatServer - fails to compile "Sketch too big"
 
     # Ethernet/TelnetClient
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/Ethernet/examples/TelnetClient/TelnetClient.ino" BOARD_ID="MightyCore:avr:164:pinout=standard,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1MHz_internal
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/Ethernet/examples/TelnetClient/TelnetClient.ino" BOARD_ID="MightyCore:avr:164:pinout=standard,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
 
     # Ethernet/UDPSendReceiveString
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/Ethernet/examples/UDPSendReceiveString/UDPSendReceiveString.ino" BOARD_ID="MightyCore:avr:164:pinout=standard,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
@@ -119,11 +117,9 @@ env:
     # Ethernet/UdpNtpClient
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/Ethernet/examples/UdpNtpClient/UdpNtpClient.ino" BOARD_ID="MightyCore:avr:164:pinout=standard,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
 
-    # Ethernet/WebClient
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/Ethernet/examples/WebClient/WebClient.ino" BOARD_ID="MightyCore:avr:164:pinout=standard,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # Ethernet/WebClient - fails to compile "Sketch too big"
 
-    # Ethernet/WebClientRepeating
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/Ethernet/examples/WebClientRepeating/WebClientRepeating.ino" BOARD_ID="MightyCore:avr:164:pinout=standard,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # Ethernet/WebClientRepeating - fails to compile "Sketch too big"
 
     # Ethernet/WebServer
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/Ethernet/examples/WebServer/WebServer.ino" BOARD_ID="MightyCore:avr:164:pinout=standard,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
@@ -215,11 +211,9 @@ env:
     # Ethernet/UdpNtpClient
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/Ethernet/examples/UdpNtpClient/UdpNtpClient.ino" BOARD_ID="MightyCore:avr:16:pinout=standard,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
 
-    # Ethernet/WebClient
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/Ethernet/examples/WebClient/WebClient.ino" BOARD_ID="MightyCore:avr:16:pinout=standard,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # Ethernet/WebClient - fails to compile "Sketch too big"
 
-    # Ethernet/WebClientRepeating
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/Ethernet/examples/WebClientRepeating/WebClientRepeating.ino" BOARD_ID="MightyCore:avr:16:pinout=standard,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # Ethernet/WebClientRepeating - fails to compile "Sketch too big"
 
     # Ethernet/WebServer
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/Ethernet/examples/WebServer/WebServer.ino" BOARD_ID="MightyCore:avr:16:pinout=standard,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
@@ -264,9 +258,7 @@ env:
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/EEPROM" BOARD_ID="MightyCore:avr:8535:pinout=standard,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
 
     # Ethernet
-    # All Ethernet examples except UDPSendReceiveString with LTO=Os_flto fail to compile "section `.text' will not fit in region `text'"
-    # pinout=bobuino, BOD=4v0, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/Ethernet/examples/UDPSendReceiveString/UDPSendReceiveString.ino" BOARD_ID="MightyCore:avr:8535:pinout=bobuino,BOD=4v0,LTO=Os_flto,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # All Ethernet examples fail to compile "section `.text' will not fit in region `text'"
 
     # Optiboot_flasher
     # pinout=sanguino, BOD=disabled, clock=12MHz_external
@@ -288,7 +280,8 @@ env:
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/Timer" BOARD_ID="MightyCore:avr:8535:pinout=standard,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
 
     # Wire
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/Wire" BOARD_ID="MightyCore:avr:8535:pinout=standard,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # pinout=bobuino, BOD=4v0, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MightyCore/avr/libraries/Wire" BOARD_ID="MightyCore:avr:8535:pinout=bobuino,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
 
 
 before_install:


### PR DESCRIPTION
The new version of the Ethernet library introduced in https://github.com/MCUdude/MightyCore/commit/8e481193c9f86a91aa156ad7d0352690d240311e increased the compile size of most example sketches of that library, causing them to no longer fit on ATmega164, ATmega16, or ATmega8535.

- Remove failing jobs from the Travis CI configuration.
- Transfer configuration option tests done in the removed jobs to other jobs.