### PR TITLE
Update missing macros section of bobuino variant

### DIFF
--- a/avr/variants/bobuino/pins_arduino.h
+++ b/avr/variants/bobuino/pins_arduino.h
@@ -149,8 +149,8 @@ const uint8_t digital_pin_to_pcint[NUM_DIGITAL_PINS] =
 
 #endif
 
-#if defined(__AVR_ATmega164A__) || defined(__AVR_ATmega164P__) || defined(__AVR_ATmega324A__) || \
-defined(__AVR_ATmega324P__) || defined(__AVR_ATmega324PA__)
+#if defined(__AVR_ATmega164PA__) || defined(__AVR_ATmega324A__) || defined(__AVR_ATmega324P__)\
+|| defined(__AVR_ATmega324PA__)
 /**** Needed to get the SD library to work. 
 Missing definitions in the iom164.h/iom324.h file ****/
 #define SPR0 0

--- a/avr/variants/bobuino/pins_arduino.h
+++ b/avr/variants/bobuino/pins_arduino.h
@@ -153,20 +153,20 @@ const uint8_t digital_pin_to_pcint[NUM_DIGITAL_PINS] =
 || defined(__AVR_ATmega324PA__)
 /**** Needed to get the SD library to work. 
 Missing definitions in the iom164.h/iom324.h file ****/
-#define SPR0 0
-#define SPR1 1
-#define CPHA 2
-#define CPOL 3
-#define MSTR 4
-#define DORD 5
-#define SPE 6
-#define SPIE 7
-#define SPSR _SFR_IO8(0x2D)
-#define SPI2X 0
-#define WCOL 6
-#define SPIF 7
-#define SPCR _SFR_IO8(0x2C)
-#define SPDR _SFR_IO8(0x2E)
+#define SPR0 SPR00
+#define SPR1 SPR10
+#define CPHA CPHA0
+#define CPOL CPOL0
+#define MSTR MSTR0
+#define DORD DORD0
+#define SPE SPE0
+#define SPIE SPIE0
+#define SPSR SPSR0
+#define SPI2X SPI2X0
+#define WCOL WCOL0
+#define SPIF SPIF0
+#define SPCR SPCR0
+#define SPDR SPDR0
 #endif
 
 // Missing definitions in iom324pb.h file


### PR DESCRIPTION
- Correct which parts missing macros are defined for in bobuino variant.
- Use existing macros to define missing macros in bobuino variant.

Reference: https://github.com/MCUdude/MightyCore/commit/743fa100b744bb59834490d4b10e1bc20ce43cfa