### PR TITLE
fix incompatible data type error in Bobduino pin assignment

### DIFF
--- a/avr/variants/bobuino/pins_arduino.h
+++ b/avr/variants/bobuino/pins_arduino.h
@@ -125,9 +125,9 @@ defined(__AVR_ATmega324P__) || defined(__AVR_ATmega324PA__) || defined(__AVR_ATm
 defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega1284__) || \
 defined(__AVR_ATmega1284P__)
 #if defined(__AVR_ATmega324PB__)
-#define PORT_NDX_TO_PCMSK(x) ((x) == 0 ? &PCMSK0 : ((x) == 1 ? &PCMSK1 : ((x) == 2 ? &PCMSK2 : ((x) == 3 ? &PCMSK3 : ((x) == 4 ? &PCMSK4 : (uint8_t )0)))))
+#define PORT_NDX_TO_PCMSK(x) ((x) == 0 ? &PCMSK0 : ((x) == 1 ? &PCMSK1 : ((x) == 2 ? &PCMSK2 : ((x) == 3 ? &PCMSK3 : ((x) == 4 ? &PCMSK4 : (uint8_t *)0)))))
 #else
-#define PORT_NDX_TO_PCMSK(x) ((x) == 0 ? &PCMSK0 : ((x) == 1 ? &PCMSK1 : ((x) == 2 ? &PCMSK2 : ((x) == 3 ? &PCMSK3 : (uint8_t )0))))
+#define PORT_NDX_TO_PCMSK(x) ((x) == 0 ? &PCMSK0 : ((x) == 1 ? &PCMSK1 : ((x) == 2 ? &PCMSK2 : ((x) == 3 ? &PCMSK3 : (uint8_t *)0))))
 #endif
 #define ifpin(p,what,ifnot)         (((p) >= 0 && (p) < NUM_DIGITAL_PINS) ? (what) : (ifnot))
 #define digitalPinToPCICR(p)    ifpin(p,&PCICR,(uint8_t *)0)


### PR DESCRIPTION
error seen on Arduino 1.8.10 using arduino-builder
MightyCore/hardware/avr/2.0.3/variants/bobuino/pins_arduino.h:130:106:
error: operands to ?: have different types 'volatile uint8_t* {aka
volatile unsigned char*}' and 'uint8_t {aka unsigned char}'
 #define PORT_NDX_TO_PCMSK(x) ((x) == 0 ? &PCMSK0 : ((x) == 1 ? &PCMSK1
: ((x) == 2 ? &PCMSK2 : ((x) == 3 ? &PCMSK3 : (uint8_t )0))))

Tested on Arduino 1.8.10/Linux installation.