### PR TITLE
Force installation of latest arduino:avr platform version during CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -308,13 +308,15 @@ before_install:
   # Check for library issues that don't affect compilation
   - set_library_testing "true"
 
-  # Install all IDE version required by the job
-  - install_ide "$IDE_VERSIONS"
-
+  # Install a version of Arduino IDE with an outdated bundled arduino:avr platform to force installation of latest arduino:avr
+  - install_ide "1.8.12"
+  # Install Arduino AVR Boards to get the AVR toolchain
+  - install_package "arduino:avr"
   # Install MightyCore from the repository
   - install_package
-  # Install beta version of Arduino AVR Boards, required for ATmega324PB
-  - install_package "arduino:avr" "https://downloads.arduino.cc/packages/package_avr_3.6.0_index.json"
+
+  # Install all IDE version required by the job
+  - install_ide "$IDE_VERSIONS"
 
 
 script:


### PR DESCRIPTION
The newest installed IDE version is used by `install_package`. When the newest version of the arduino:avr platform is already bundled with that IDE version, the installation is skipped. 

Previously, the newest installed IDE version had an outdated bundled `arduino:avr version`, so a global installation of the latest version of the platform was made, which was used by all IDE versions during the CI build.

After updating the per1234/arduino-ci-script CI script, the latest IDE version is now installed. Because this IDE version currently bundles the latest version of arduino:avr, the installation of arduino:avr is skipped. This results in each compilation using the AVR toolchain bundled with that version of the IDE. The bundled AVR toolchain of the older IDE versions used by the CI build don't support the PB parts, which resulted in the compilations for those boards with the old IDE versions in the CI build failing.

The workaround is to use the following procedure:
1. Install version of Arduino IDE with an outdated bundled arduino:avr platform
1. Instal arduino:avr platform (which results in a global installation of the latest version of the platform).
1. Install all IDE versions needed for the CI build.