### PR TITLE
Enable gnu++17 support by default

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -25,7 +25,7 @@ compiler.c.elf.flags={compiler.warning_flags} -Os -Wl,--gc-sections,--section-st
 compiler.c.elf.cmd=avr-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp
 compiler.cpp.cmd=avr-g++
-compiler.cpp.flags=-c -g -Os {compiler.warning_flags} -std=gnu++17 -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -MMD
+compiler.cpp.flags=-c -g -Os {compiler.warning_flags}  -std=gnu++17 -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -MMD
 compiler.ar.cmd={ltoarcmd}
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=avr-objcopy

--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -25,7 +25,7 @@ compiler.c.elf.flags={compiler.warning_flags} -Os -Wl,--gc-sections,--section-st
 compiler.c.elf.cmd=avr-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp
 compiler.cpp.cmd=avr-g++
-compiler.cpp.flags=-c -g -Os {compiler.warning_flags} -std=gnu++11 -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -MMD
+compiler.cpp.flags=-c -g -Os {compiler.warning_flags} -std=gnu++17 -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -MMD
 compiler.ar.cmd={ltoarcmd}
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=avr-objcopy


### PR DESCRIPTION
This pull request is dependent on https://github.com/MCUdude/MCUdude_corefiles/pull/33 being merged first. 

Changes the compiler language standard from gnu++11 to gnu++17.