### PR TITLE
Add the ability to turn D1 into CLKO for the Atmega1284, 644, and 164 chips

### DIFF
--- a/avr/boards.txt
+++ b/avr/boards.txt
@@ -240,6 +240,19 @@ menu.bootloader=Bootloader
 1284.menu.clock.1MHz_internal.build.clock_speed={build.f_cpu}
 1284.menu.clock.1MHz_internal.build.f_cpu=1000000L
 
+1284.menu.clock.16MHz_external_with_clko=External 16 MHz (D1 acting as CLKO)
+1284.menu.clock.16MHz_external_with_clko.upload.speed=115200
+1284.menu.clock.16MHz_external_with_clko.bootloader.low_fuses=0xb7
+1284.menu.clock.16MHz_external_with_clko.build.clkpr=
+1284.menu.clock.16MHz_external_with_clko.build.clock_speed={build.f_cpu}
+1284.menu.clock.16MHz_external_with_clko.build.f_cpu=16000000L
+
+1284.menu.clock.20MHz_external_with_clko=External 20 MHz (D1 acting as CLKO)
+1284.menu.clock.20MHz_external_with_clko.upload.speed=115200
+1284.menu.clock.20MHz_external_with_clko.bootloader.low_fuses=0xb7
+1284.menu.clock.20MHz_external_with_clko.build.clkpr=
+1284.menu.clock.20MHz_external_with_clko.build.clock_speed={build.f_cpu}
+1284.menu.clock.20MHz_external_with_clko.build.f_cpu=20000000L
 
 
 ###########################
@@ -445,6 +458,20 @@ menu.bootloader=Bootloader
 644.menu.clock.1MHz_internal.build.clkpr=
 644.menu.clock.1MHz_internal.build.clock_speed={build.f_cpu}
 644.menu.clock.1MHz_internal.build.f_cpu=1000000L
+
+644.menu.clock.16MHz_external_with_clko=External 16 MHz (D1 acting as CLKO)
+644.menu.clock.16MHz_external_with_clko.upload.speed=115200
+644.menu.clock.16MHz_external_with_clko.bootloader.low_fuses=0xb7
+644.menu.clock.16MHz_external_with_clko.build.clkpr=
+644.menu.clock.16MHz_external_with_clko.build.clock_speed={build.f_cpu}
+644.menu.clock.16MHz_external_with_clko.build.f_cpu=16000000L
+
+644.menu.clock.20MHz_external_with_clko=External 20 MHz (D1 acting as CLKO)
+644.menu.clock.20MHz_external_with_clko.upload.speed=115200
+644.menu.clock.20MHz_external_with_clko.bootloader.low_fuses=0xb7
+644.menu.clock.20MHz_external_with_clko.build.clkpr=
+644.menu.clock.20MHz_external_with_clko.build.clock_speed={build.f_cpu}
+644.menu.clock.20MHz_external_with_clko.build.f_cpu=20000000L
 
 
 
@@ -877,6 +904,20 @@ menu.bootloader=Bootloader
 164.menu.clock.1MHz_internal.build.clkpr=
 164.menu.clock.1MHz_internal.build.clock_speed={build.f_cpu}
 164.menu.clock.1MHz_internal.build.f_cpu=1000000L
+
+164.menu.clock.16MHz_external_with_clko=External 16 MHz (D1 acting as CLKO)
+164.menu.clock.16MHz_external_with_clko.upload.speed=115200
+164.menu.clock.16MHz_external_with_clko.bootloader.low_fuses=0xb7
+164.menu.clock.16MHz_external_with_clko.build.clkpr=
+164.menu.clock.16MHz_external_with_clko.build.clock_speed={build.f_cpu}
+164.menu.clock.16MHz_external_with_clko.build.f_cpu=16000000L
+
+164.menu.clock.20MHz_external_with_clko=External 20 MHz (D1 acting as CLKO)
+164.menu.clock.20MHz_external_with_clko.upload.speed=115200
+164.menu.clock.20MHz_external_with_clko.bootloader.low_fuses=0xb7
+164.menu.clock.20MHz_external_with_clko.build.clkpr=
+164.menu.clock.20MHz_external_with_clko.build.clock_speed={build.f_cpu}
+164.menu.clock.20MHz_external_with_clko.build.f_cpu=20000000L
 
 
 


### PR DESCRIPTION
I have been using the atmega1284p as a chipset to interface with an intel i960Sx processor.
One of the features of AVR chips is the ability to output the MCU clock signal through the CLKO pin. 
This pull request adds this ability through the clock speed menu in the arduino IDE. 

From the commit log: 

Most AVR chips provide the ability to emit the processor's clock cycle
on a specific GPIO (the name provided is CLKO). This is done by changing
some of the fuses at bootloader programming time. The upside is that the
same clock that powers the microcontroller can be provided to other
devices in your project.

The downside is that you lose the use of the CLKO pin as a GPIO.

I have exposed this option as a different speed grade for 16 and 20 MHz
for the 1284, 644, and 164 Atmega chips. This ability isn't bound to
just 16 and 20MHz speeds but I have no need for the other speeds in my own projects.

I also only exposed this for the 1284, 644, and 164 because those are
the chips I actually own and can easily test. I did not want to expose the
option on chips that I myself do not own and cause a problem for someone
else.