### PR TITLE
Adding ATmega32U4 Arduino as ISP programmer

### DIFF
--- a/avr/externalprogrammers.txt
+++ b/avr/externalprogrammers.txt
@@ -59,6 +59,15 @@ arduinoasisp.program.speed=19200
 arduinoasisp.program.tool=avrdude
 arduinoasisp.program.extra_params=-P{serial.port} -b{program.speed}
 
+arduinoasispatmega32u4.name=Arduino as ISP (ATmega32U4) (MightyCore)
+arduinoasispatmega32u4.communication=serial
+arduinoasispatmega32u4.protocol=arduino
+arduinoasispatmega32u4.speed=19200
+arduinoasispatmega32u4.program.protocol=arduino
+arduinoasispatmega32u4.program.speed=19200
+arduinoasispatmega32u4.program.tool=avrdude
+arduinoasispatmega32u4.program.extra_params=-P{serial.port} -b{program.speed}
+
 usbGemma.name=Arduino Gemma
 usbGemma.protocol=arduinogemma
 usbGemma.program.tool=avrdude

--- a/avr/programmers.txt
+++ b/avr/programmers.txt
@@ -65,6 +65,15 @@ arduinoasisp.program.speed=19200
 arduinoasisp.program.tool=avrdude
 arduinoasisp.program.extra_params=-P{serial.port} -b{program.speed}
 
+arduinoasispatmega32u4.name=Arduino as ISP (ATmega32U4) (MightyCore)
+arduinoasispatmega32u4.communication=serial
+arduinoasispatmega32u4.protocol=arduino
+arduinoasispatmega32u4.speed=19200
+arduinoasispatmega32u4.program.protocol=arduino
+arduinoasispatmega32u4.program.speed=19200
+arduinoasispatmega32u4.program.tool=avrdude
+arduinoasispatmega32u4.program.extra_params=-P{serial.port} -b{program.speed}
+
 atmel_ice.name=Atmel-ICE (AVR) (MightyCore)
 atmel_ice.communication=usb
 atmel_ice.protocol=atmelice_isp


### PR DESCRIPTION
This allows the use of ATmega32U4-based boards (e.g. Arduino Leonardo) as an ISP for MightyCore.

Reference: https://github.com/arduino/ArduinoCore-avr/blob/master/programmers.txt#L53-L60