### PR TITLE
fix shiftIn

### DIFF
--- a/avr/cores/MCUdude_corefiles/wiring_shift.c
+++ b/avr/cores/MCUdude_corefiles/wiring_shift.c
@@ -26,12 +26,12 @@ uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder) {
   uint8_t value = 0;
   uint8_t i;
 
-  for (i = 0; i < 8; ++i) {
-    digitalWrite(clockPin, HIGH);
+  for (i = 0; i < 8; i++) {
     if (bitOrder == LSBFIRST)
       value |= digitalRead(dataPin) << i;
     else
       value |= digitalRead(dataPin) << (7 - i);
+    digitalWrite(clockPin, HIGH);
     digitalWrite(clockPin, LOW);
   }
   return value;


### PR DESCRIPTION
When the edge goes up, it shifts by one bit. If shifting occurs before the first bit is read, we get the 2nd bit.